### PR TITLE
在 GitHub Actions 中添加 Docker 镜像构建和缓存功能

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,78 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches:
+      - dev
+    tags:
+      - 'v*'
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  docker_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
+      - name: Set up docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          version: latest
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GT_Token }}
+        
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=pep440,pattern={{raw}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            tpye=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+
+      - name: Build dev branch and push
+        if: github.ref == 'refs/heads/dev'
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build release and push
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
- 添加 Docker 构建和发布的 Github Action
- 为 `dev` 分支和 带有`v*`的 tag 构建和发布 Docker 镜像
- 使用 `ghcr.io` 作为 Docker 注册表，并通过 Github 凭据进行身份验证
- 使用 `docker/metadata-action` 为 Docker 镜像设置标签和标记
- 使用 Github Actions 缓存模式缓存 Docker 镜像。