### PR TITLE
Support for getting a token from a url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 ### Custom Options
 **The following settings are optional and not required.**
 - `-port` or `-p` : Listening port. Default is `1188`.
-- `-token` : Access token. If you have set it up, each request will need to include an `Authorization` header.
+- `-token` : Access token. If you have set it up, each request will needs to include an `Authorization` header or `token` parameter in the parameters.
 - `-authkey` : DeepL Official `AuthKey`. If you have set it up, after the 429 response, the official AuthKey will be used for the request. If multiple authKeys are used simultaneously, they need to be separated by commas.
 
 #### Requesting a token-protected **DeepLX API** instance using the `curl`
@@ -75,6 +75,16 @@
 curl -X POST http://localhost:1188/translate \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer your_access_token" \
+-d '{
+    "text": "Hello, world!",
+    "source_lang": "EN",
+    "target_lang": "DE"
+}'
+```
+or
+```
+curl -X POST http://localhost:1188/translate?token=your_access_token \
+-H "Content-Type: application/json" \
 -d '{
     "text": "Hello, world!",
     "source_lang": "EN",

--- a/main.go
+++ b/main.go
@@ -274,8 +274,9 @@ func main() {
 		c.BindJSON(&req)
 
 		if cfg.Token != "" {
-			providedToken := c.GetHeader("Authorization")
-			if providedToken != "Bearer "+cfg.Token {
+			providedTokenInQuery := c.Query("token")
+			providedTokenInHeader := c.GetHeader("Authorization")
+			if providedTokenInHeader != "Bearer "+cfg.Token && providedTokenInQuery != cfg.Token {
 				c.JSON(http.StatusUnauthorized, gin.H{
 					"code":    http.StatusUnauthorized,
 					"message": "Invalid access token",


### PR DESCRIPTION
Solve the problem that  Immersive translation does not support adding token in Header .

ex: http://[IP]:1188/translate?token=xxxxxx