### PR TITLE
解决沉浸式翻译使用 /v1/translate端点时传入多余cookie导致dl_session错误设置的问题

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,9 +176,13 @@ func main() {
 			return
 		}
 
-		cookie := c.GetHeader("Cookie")
-		if cookie != "" {
-			dlSession = strings.Replace(cookie, "dl_session=", "", -1)
+		if cookie := c.GetHeader("Cookie"); cookie != "" {
+			for _, part := range strings.Split(cookie, ";") {
+				if strings.HasPrefix(part, "dl_session=") {
+					dlSession = strings.TrimPrefix(part, "dl_session=")
+					break
+				}
+			}
 		}
 
 		if dlSession == "" {


### PR DESCRIPTION
沉浸式翻译会传入请求头：
```
Accept: */*
Accept-Encoding: gzip, deflate
Accept-Language: zh-CN,zh;q=0.9
Content-Length: 60
Cookie: psession=327fdbc7-c5e6-4df6-92c7-43b1781683b0
Host: "127.0.0.1:11888"
Origin: "chrome-extension://bpoadfkcbjbfhfodiogcnhhhpibjhbnh"
Proxy-Connection: keep-alive
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36
content-type: application/json
```
之前的cookie读取方式会导致dl_session错误变更导致503