### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 DeepLX
+
+# macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
macOS Finder writes `.DS_Store` sidecar files into every directory it touches. They contain user-local UI state (icon positions, view modes) and should never be tracked or shipped.