### PR TITLE
feat(docker): improve Dockerfile building with non-root user and replacing CMD with ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,8 @@ RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o deeplx .
 
 FROM alpine:latest
 WORKDIR /app
-COPY --from=builder /go/src/github.com/OwO-Network/DeepLX/deeplx /app/deeplx
-CMD ["/app/deeplx"]
+RUN addgroup -S deeplx && adduser -h /app -G deeplx -SH deeplx
+USER deeplx
+COPY --from=builder --chown=deeplx /go/src/github.com/OwO-Network/DeepLX/deeplx /app/deeplx
+EXPOSE 1188
+ENTRYPOINT ["/app/deeplx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o deeplx .
 
 FROM alpine:latest
 WORKDIR /app
-RUN addgroup -g 1000 -S deeplx && adduser -h /app -G deeplx -SH -u 1000 deeplx
-USER 1000:1000
-COPY --from=builder --chown=deeplx /go/src/github.com/OwO-Network/DeepLX/deeplx /app/deeplx
+RUN addgroup -S deeplx && adduser -h /app -G deeplx -SH deeplx
+USER deeplx:deeplx
+COPY --from=builder --chown=deeplx:deeplx /go/src/github.com/OwO-Network/DeepLX/deeplx /app/deeplx
 EXPOSE 1188
 ENTRYPOINT ["/app/deeplx"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o deeplx .
 
 FROM alpine:latest
 WORKDIR /app
-RUN addgroup -S deeplx && adduser -h /app -G deeplx -SH deeplx
-USER deeplx
+RUN addgroup -g 1000 -S deeplx && adduser -h /app -G deeplx -SH -u 1000 deeplx
+USER 1000:1000
 COPY --from=builder --chown=deeplx /go/src/github.com/OwO-Network/DeepLX/deeplx /app/deeplx
 EXPOSE 1188
 ENTRYPOINT ["/app/deeplx"]


### PR DESCRIPTION
Resolves  #221.

I also changed the followings for the Dockerfile:
1. Replace CMD with ENTRYPOINT so that user can directly pass arguments to deeplx binary when running `docker run`.
2. EXPOSE port 1188 (served as documentation purpose, see [Dockerfile reference](https://docs.docker.com/reference/dockerfile/#expose))

If this PR is accepted, may I know when this change will be published?