### PR TITLE
fix(service): return 500 instead of crashing on translation error

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -127,7 +127,11 @@ func Router(cfg *Config) *gin.Engine {
 
 		result, err := translate.TranslateByDeepLX(sourceLang, targetLang, translateText, tagHandling, proxyURL, "")
 		if err != nil {
-			log.Fatalf("Translation failed: %s", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"code":    http.StatusInternalServerError,
+				"message": "Translation failed: " + err.Error(),
+			})
+			return
 		}
 
 		if result.Code == http.StatusOK {
@@ -191,7 +195,11 @@ func Router(cfg *Config) *gin.Engine {
 
 		result, err := translate.TranslateByDeepLX(sourceLang, targetLang, translateText, tagHandling, proxyURL, dlSession)
 		if err != nil {
-			log.Fatalf("Translation failed: %s", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"code":    http.StatusInternalServerError,
+				"message": "Translation failed: " + err.Error(),
+			})
+			return
 		}
 
 		if result.Code == http.StatusOK {
@@ -243,7 +251,11 @@ func Router(cfg *Config) *gin.Engine {
 
 		result, err := translate.TranslateByDeepLX("", targetLang, translateText, "", proxyURL, "")
 		if err != nil {
-			log.Fatalf("Translation failed: %s", err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"code":    http.StatusInternalServerError,
+				"message": "Translation failed: " + err.Error(),
+			})
+			return
 		}
 
 		if result.Code == http.StatusOK {


### PR DESCRIPTION
## Problem
The `/translate`, `/v1/translate` and `/v2/translate` handlers call `log.Fatalf` when `TranslateByDeepLX` returns an error. `log.Fatalf` calls `os.Exit(1)`, so a single failed translation request tears down the entire server process — an unintended DoS vector.

## Fix
Return a `500` JSON response and keep serving, consistent with how the handlers already report non-200 results.

## Verified
- `go build ./...` and `go vet ./...` clean
- Ran the server locally — normal translation still returns 200 (`"Hello, world"` → `"你好，世界"`), and malformed input returns its JSON error without taking the process down.
