### PR TITLE
fix(service): validate request body on /translate and /v1/translate

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -108,7 +108,13 @@ func Router(cfg *Config) *gin.Engine {
 	// Free API endpoint, No Pro Account required
 	r.POST("/translate", authMiddleware(cfg), func(c *gin.Context) {
 		req := PayloadFree{}
-		c.BindJSON(&req)
+		if err := c.BindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"code":    http.StatusBadRequest,
+				"message": "Invalid request payload",
+			})
+			return
+		}
 
 		sourceLang := req.SourceLang
 		targetLang := req.TargetLang
@@ -156,7 +162,13 @@ func Router(cfg *Config) *gin.Engine {
 	// Pro API endpoint, Pro Account required
 	r.POST("/v1/translate", authMiddleware(cfg), func(c *gin.Context) {
 		req := PayloadFree{}
-		c.BindJSON(&req)
+		if err := c.BindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"code":    http.StatusBadRequest,
+				"message": "Invalid request payload",
+			})
+			return
+		}
 
 		sourceLang := req.SourceLang
 		targetLang := req.TargetLang


### PR DESCRIPTION
## What

`/translate` and `/v1/translate` call `c.BindJSON` but ignore the returned error, so a malformed JSON body falls through and is processed as an empty payload. This checks the error and returns `400 Invalid request payload`, consistent with the existing handling in `/v2/translate`.

## Test

- `go vet ./...` / `go build` clean
- Ran the server locally:
  - `POST /translate` with `{bad`  -> 400 (previously fell through to an empty payload)
  - `POST /translate` with empty body -> 400
  - valid request unchanged -> 200 with translation