### PR TITLE
fix(install): detect architecture instead of hardcoding amd64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,20 @@ install_deeplx(){
         exit 1
     fi
     echo -e "DeepLX latest version: ${last_version}, Start install..."
-    wget -q -N --no-check-certificate -O /usr/bin/deeplx https://github.com/OwO-Network/DeepLX/releases/download/${last_version}/deeplx_linux_amd64
+
+    arch=$(uname -m)
+    case "${arch}" in
+        x86_64 | amd64) file_arch="amd64" ;;
+        aarch64 | arm64) file_arch="arm64" ;;
+        i386 | i686) file_arch="386" ;;
+        mips) file_arch="mips" ;;
+        *)
+            echo -e "${red}Unsupported architecture: ${arch}${plain}"
+            exit 1
+            ;;
+    esac
+
+    wget -q -N --no-check-certificate -O /usr/bin/deeplx https://github.com/OwO-Network/DeepLX/releases/download/${last_version}/deeplx_linux_${file_arch}
 
     chmod +x /usr/bin/deeplx
     wget -q -N --no-check-certificate -O /etc/systemd/system/deeplx.service https://raw.githubusercontent.com/OwO-Network/DeepLX/main/deeplx.service


### PR DESCRIPTION
## What

install.sh always downloaded the `deeplx_linux_amd64` asset, so it installed an x86-64 binary on every machine — non-amd64 hosts (arm64, 386, mips) got a binary that won't run. This detects the architecture via `uname -m` and maps it to the matching release asset; unsupported architectures exit with a clear error instead of silently installing the wrong binary.

## Test

- `bash -n install.sh` passes.
- Mapping verified against the actual release assets (`deeplx_linux_{amd64,arm64,386,mips}` are all published by `.cross_compile.sh`).