### PR TITLE
ci: drop dead golint step, align Go to go.mod 1.25, bump checkout to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,15 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24.2'
-
-      - name: Install golint
-        run: go install golang.org/x/lint/golint@latest
+          go-version: '1.25'
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.24.2"
+          go-version: "1.25"
 
       - name: Build
         env:


### PR DESCRIPTION
## What

A few CI housekeeping fixes:

- **Remove the dead golint step** — `ci.yaml` installed `golang.org/x/lint/golint` but never invoked it, and golint has been deprecated/frozen since 2021.
- **Align the CI Go version to go.mod** — the workflows pinned `1.24.2` while `go.mod` and the Dockerfile are on `1.25`; bump them to `1.25`.
- **Bump `actions/checkout@v3` to `v4`** in `ci.yaml` and `docker.yaml` (`release.yaml` was already on v4), off the deprecated Node 16 runtime.

## Test

- All three workflow files parse as valid YAML.
- No build or runtime code touched.